### PR TITLE
Support specifying an end point

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Good heuristic for the traveling salesman problem using simulated annealing.
 * [salesman](#module_salesman)
     * [~Point](#module_salesman..Point)
         * [new Point(x, y)](#new_module_salesman..Point_new)
-    * [~solve(points, [temp_coeff], [callback], [callback])](#module_salesman..solve) ⇒ <code>Array.&lt;number&gt;</code>
+    * [~solve(points, [temp_coeff], [callback], [callback], [keep_end])](#module_salesman..solve) ⇒ <code>Array.&lt;number&gt;</code>
 
 <a name="module_salesman..Point"></a>
 
@@ -30,7 +30,7 @@ Represents a point in two dimensions. Used as the input for `solve`.
 
 <a name="module_salesman..solve"></a>
 
-### salesman~solve(points, [temp_coeff], [callback], [callback]) ⇒ <code>Array.&lt;number&gt;</code>
+### salesman~solve(points, [temp_coeff], [callback], [callback], [keep_end]) ⇒ <code>Array.&lt;number&gt;</code>
 Solves the following problem:
  Given a list of points and the distances between each pair of points,
  what is the shortest possible route that visits each point exactly
@@ -45,6 +45,7 @@ Solves the following problem:
 | [temp_coeff] | <code>number</code> | <code>0.999</code> | changes the convergence speed of the algorithm. Smaller values (0.9) work faster but give poorer solutions, whereas values closer to 1 (0.99999) work slower, but give better solutions. |
 | [callback] | <code>function</code> |  | An optional callback to be called after each iteration. |
 | [callback] | <code>function</code> | <code>euclidean</code> | An optional argument to specify how distances are calculated. The function takes two Point objects as arguments and returns a number for distance. Defaults to simple Euclidean distance calculation. |
+| [keep_end] | <code>boolean</code> | <code>false</code> | An optional argument to specify if the last point is fixed. If false then the minimum circuit is calculated, if true the minimum path from first to last node is calculated. |
 
 **Example**  
 ```js

--- a/salesman.js
+++ b/salesman.js
@@ -17,10 +17,12 @@
  * along with an array which maintains a record of distances between points.
  * @param {Points[]} points The points in the path.
  * @param {Function} distanceFunc The function to use to calculate the distance between two points.
+ * @param {boolean} keepEnd Specify if the last point is fixed. If false then the minimum circuit is calculated, if true the minimum path from first to last node is calculated.
  */
-function Path(points, distanceFunc) {
+function Path(points, distanceFunc, keepEnd) {
   this.points = points;
   this.distanceFunc = distanceFunc;
+  this.keepEnd = keepEnd;
   this.initializeOrder();
   this.initializeDistances();
 }
@@ -138,7 +140,7 @@ Path.prototype.distance = function(i, j) {
  * @returns {number} A random index.
  */
 Path.prototype.randomPos = function() {
-  return 1 + Math.floor(Math.random() * (this.points.length - 1));
+  return 1 + Math.floor(Math.random() * (this.points.length - (this.keepEnd ? 2 : 1)));
 };
 
 /**
@@ -174,8 +176,8 @@ function Point(x, y) {
  * var ordered_points = solution.map(i => points[i]);
  * // ordered_points now contains the points, in the order they ought to be visited.
  **/
-function solve(points, temp_coeff = 0.999, callback, distance = euclidean) {
-  var path = new Path(points, distance);
+function solve(points, temp_coeff = 0.999, callback, distance = euclidean, keep_end = false) {
+  var path = new Path(points, distance, keep_end);
   // Optimization: If there is only one point in the list, there is no path.
   if (points.length < 2) return path.order;
   // Optimization: If the user would provide a bad input, end immediately.

--- a/test.js
+++ b/test.js
@@ -4,11 +4,12 @@ var salesman = require("./salesman.js");
 var tests = [
     {q:[[0,0]], r:[0]},
     {q:[[0,0],[1,1]], r:[0,1]},
+    {q:[[0,0],[2,2],[1,1]], r:[0,1,2], e: true},
 ];
 
 
 for(let test of tests) {
     var points = test.q.map(([x,y])=>new salesman.Point(x,y));
-    var res = salesman.solve(points);
+    var res = salesman.solve(points, undefined, undefined, undefined, test.e);
     assert.deepEqual(test.r, res);
 }


### PR DESCRIPTION
If the `keep_end` parameter to the `solve` function is true then the last point will remain the last point in the result. This allows calculation of minimum path rather than minimum circuit.

Resolves https://github.com/lovasoa/salesman.js/issues/2